### PR TITLE
Creates implementation for supporting offhand.

### DIFF
--- a/src/com/gmail/zariust/otherdrops/EquipmentSlotResolver.java
+++ b/src/com/gmail/zariust/otherdrops/EquipmentSlotResolver.java
@@ -1,0 +1,73 @@
+package com.gmail.zariust.otherdrops;
+
+import org.bukkit.Material;
+import org.bukkit.entity.HumanEntity;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.PlayerInventory;
+
+import static org.bukkit.inventory.EquipmentSlot.HAND;
+import static org.bukkit.inventory.EquipmentSlot.OFF_HAND;
+
+/**
+ * Utility for resolving the {@link EquipmentSlot} containing a player's weapon for an
+ * {@link EntityDamageByEntityEvent}. This is used since that event type doesn't provide a
+ * way for finding out the equipment slot.
+ */
+public class EquipmentSlotResolver {
+
+    /**
+     * Resolve the used equipment slot from the damage cause of an {@link EntityDamageByEntityEvent}.
+     * @param damageCause The damage cause of the event.
+     * @param damager The {@link HumanEntity} who caused the event.
+     * @return The used equipment slot. {@code null} if it could not be resolved.
+     */
+    public static EquipmentSlot resolve(DamageCause damageCause, HumanEntity damager) {
+        final PlayerInventory damagerInventory = damager.getInventory();
+
+        return switch (damageCause) {
+            case ENTITY_ATTACK ->
+                // Melee attacks can only be performed from the main hand.
+                // Therefore, no additional checks are required.
+                    HAND;
+            case PROJECTILE ->
+                // Ranged damage
+                    getHandWithMaterial(damagerInventory, Material.BOW, true);
+            case MAGIC ->
+                // Potion
+                    getHandWithMaterial(damagerInventory, Material.SPLASH_POTION, true);
+            default -> null;
+        };
+
+    }
+
+    /**
+     * Get the hand in which a player is holding an item with a specific material.
+     * @param playerInventory The inventory of the player.
+     * @param material The material of the item that the player should be holding.
+     * @param preferMainHand Whether to prefer the player's main hand ({@code true}) or the
+     *                       off-hand ({@code false}), in case the player is holding an item with
+     *                       the requested material in both hands.
+     * @return The {@link EquipmentSlot} representing the hand in which the player is holding an
+     *         item with the requested material. {@code null}, in case an item meeting the requirements
+     *         was found in none of the player's hands.
+     */
+    public static EquipmentSlot getHandWithMaterial(PlayerInventory playerInventory, Material material,
+                                                     boolean preferMainHand) {
+        boolean inMainHand = playerInventory.getItemInMainHand().getType() == material;
+        boolean inOffHand = playerInventory.getItemInOffHand().getType() == material;
+
+        if (inMainHand && inOffHand) {
+            // If the player is holding an item with the requested material
+            // in both hands, we will return the preferred hand here.
+            return preferMainHand ? HAND : OFF_HAND;
+        } else if (inMainHand) {
+            return HAND;
+        } else if (inOffHand) {
+            return OFF_HAND;
+        } else {
+            return null;
+        }
+    }
+}

--- a/src/com/gmail/zariust/otherdrops/OtherDropsCommand.java
+++ b/src/com/gmail/zariust/otherdrops/OtherDropsCommand.java
@@ -37,6 +37,7 @@ import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.metadata.MetadataValue;
 import org.bukkit.util.BlockIterator;
@@ -301,7 +302,7 @@ public class OtherDropsCommand implements CommandExecutor {
                 }
 
                 DropFlags flags = DropType.flags(dsl.player, (dsl.player == null ? null : new PlayerSubject(
-                        dsl.player)), false, true, false, OtherDrops.rng, "odd", "odd", "");
+                        dsl.player, EquipmentSlot.HAND)), false, true, false, OtherDrops.rng, "odd", "odd", "");
                 DropResult dropResult = drop.drop(dsl.loc, (Target) null,
                         (Location) null, 1, flags);
 

--- a/src/com/gmail/zariust/otherdrops/event/OccurredEvent.java
+++ b/src/com/gmail/zariust/otherdrops/event/OccurredEvent.java
@@ -22,6 +22,7 @@ import com.gamingmesh.jobs.api.JobsLevelUpEvent;
 import com.gamingmesh.jobs.api.JobsPaymentEvent;
 import com.gmail.zariust.common.Verbosity;
 import com.gmail.zariust.otherdrops.Dependencies;
+import com.gmail.zariust.otherdrops.EquipmentSlotResolver;
 import com.gmail.zariust.otherdrops.Log;
 import com.gmail.zariust.otherdrops.options.ConfigOnly;
 import com.gmail.zariust.otherdrops.options.Weather;
@@ -46,6 +47,7 @@ import org.bukkit.event.entity.*;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import org.bukkit.event.player.*;
 import org.bukkit.event.vehicle.VehicleDestroyEvent;
+import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.HashSet;
@@ -95,7 +97,7 @@ public class OccurredEvent extends AbstractDropEvent implements Cancellable {
         }
         setLocationWorldBiomeLight(block);
         setWeatherTimeHeight(location);
-        setTool(evt.getPlayer());
+        setTool(evt.getPlayer(), EquipmentSlot.HAND); // Block break can only be from main hand
         attackRange = measureRange(
                 location,
                 evt.getPlayer().getLocation(),
@@ -150,7 +152,11 @@ public class OccurredEvent extends AbstractDropEvent implements Cancellable {
         setWeatherTimeHeight(location);
         if (evt instanceof EntityDamageByEntityEvent) {
             EntityDamageByEntityEvent evt2 = (EntityDamageByEntityEvent) evt;
-            setTool(evt2.getDamager());
+            if(evt2.getDamager() instanceof Player p) {
+                setTool(evt2.getDamager(), EquipmentSlotResolver.resolve(evt2.getCause(), p));
+            } else {
+                setTool(evt2.getDamager(), null);
+            }
             if (tool != null)
                 attackRange = measureRange(location, evt2.getDamager().getLocation(), "Entity '" + e + "' damaged by '" + tool.toString() + "'");
         } else
@@ -166,12 +172,12 @@ public class OccurredEvent extends AbstractDropEvent implements Cancellable {
         setWeatherTimeHeight(location);
         if (evt instanceof EntityDamageByEntityEvent) {
             EntityDamageByEntityEvent evt2 = (EntityDamageByEntityEvent) evt;
-            setTool(evt2.getDamager());
-            if (evt2.getDamager() == null) {
-                Log.logInfo("EntityDamageEvent: damager is null, please inform developer.");
-            } else if (e == null) {
-                Log.logInfo("EntityDamageEvent: entity is null, please inform developer.");
-            } else if (tool == null) {
+            if(evt2.getDamager() instanceof Player p) {
+                setTool(evt2.getDamager(), EquipmentSlotResolver.resolve(evt2.getCause(), p));
+            } else {
+                setTool(evt2.getDamager(), null);
+            }
+            if (tool == null) {
                 if (!(e instanceof TNTPrimed)) {
                     Log.logInfo(
                             "EntityDamageEvent: tool is null, please inform developer if this wasn't due to TNT (or TNT minecart).",
@@ -203,7 +209,7 @@ public class OccurredEvent extends AbstractDropEvent implements Cancellable {
         event = evt;
         setLocationWorldBiomeLight(evt.getVehicle());
         setWeatherTimeHeight(location);
-        setTool(evt.getAttacker()); // Note: getAttacker is NULL for
+        setTool(evt.getAttacker(), EquipmentSlot.HAND); // Note: getAttacker is NULL for
                                     // environmental attack/break
         // environmental attacks (eg. burning) do not have a location, so range
         // is not valid.
@@ -251,7 +257,7 @@ public class OccurredEvent extends AbstractDropEvent implements Cancellable {
         attackRange = measureRange(location, evt.getPlayer().getLocation(),
                 "Player '" + evt.getPlayer().getName() + "' interacted with "
                         + block);
-        setTool(evt.getPlayer());
+        setTool(evt.getPlayer(), evt.getHand());
         setRegions();
     }
 
@@ -263,7 +269,7 @@ public class OccurredEvent extends AbstractDropEvent implements Cancellable {
         attackRange = measureRange(location, evt.getPlayer().getLocation(),
                 "Player '" + evt.getPlayer().getName() + "' interacted with "
                         + evt.getRightClicked());
-        setTool(evt.getPlayer());
+        setTool(evt.getPlayer(), evt.getHand());
         setRegions();
     }
 
@@ -346,7 +352,7 @@ public class OccurredEvent extends AbstractDropEvent implements Cancellable {
         event = null;
         setLocationWorldBiomeLight(block);
         setWeatherTimeHeight(location);
-        setTool(agent);
+        setTool(agent, EquipmentSlot.HAND); // default to main hand?
         setRegions();
     }
 
@@ -426,7 +432,7 @@ public class OccurredEvent extends AbstractDropEvent implements Cancellable {
         super(getEntityTarget(entity), action);
         event = null;
         setLocationWorldBiomeLight(entity);
-        setTool(agent);
+        setTool(agent, EquipmentSlot.HAND); // default to main hand?
         setRegions();
     }
 
@@ -509,7 +515,7 @@ public class OccurredEvent extends AbstractDropEvent implements Cancellable {
         super(targ, action, true);
         event = null;
         setLocationWorldBiomeLight(targ);
-        setTool(agent);
+        setTool(agent, EquipmentSlot.HAND);
         setRegions();
     }
 
@@ -556,11 +562,11 @@ public class OccurredEvent extends AbstractDropEvent implements Cancellable {
     }
 
     public OccurredEvent(PlayerFishEvent evt) {
-        super(new PlayerSubject(evt.getPlayer()), Trigger.FISH_CAUGHT);
+        super(new PlayerSubject(evt.getPlayer(), evt.getHand()), Trigger.FISH_CAUGHT);
         event = evt;
         setLocationWorldBiomeLight(evt.getCaught().getLocation().getBlock());
         setWeatherTimeHeight(location);
-        setTool(evt.getPlayer());
+        setTool(evt.getPlayer(), evt.getHand());
         setRegions();
         fishingLocation = evt.getHook().getLocation();
     }
@@ -568,11 +574,11 @@ public class OccurredEvent extends AbstractDropEvent implements Cancellable {
     // Yes, this needs to be a separate constructor as the "super" has to be on
     // the first line and includes the action
     public OccurredEvent(PlayerFishEvent evt, String string) {
-        super(new PlayerSubject(evt.getPlayer()), Trigger.FISH_FAILED);
+        super(new PlayerSubject(evt.getPlayer(), evt.getHand()), Trigger.FISH_FAILED);
         event = evt;
         setLocationWorldBiomeLight(evt.getPlayer().getLocation().getBlock());
         setWeatherTimeHeight(location);
-        setTool(evt.getPlayer());
+        setTool(evt.getPlayer(), evt.getHand());
         setRegions();
         fishingLocation = evt.getHook().getLocation();
     }
@@ -642,7 +648,7 @@ public class OccurredEvent extends AbstractDropEvent implements Cancellable {
 
         setLocationWorldBiomeLight(evt.getPlayer().getLocation().getBlock());
         setWeatherTimeHeight(location);
-        setTool(evt.getPlayer());
+        setTool(evt.getPlayer(), EquipmentSlot.HAND);
         setRegions();
 
     }
@@ -668,21 +674,21 @@ public class OccurredEvent extends AbstractDropEvent implements Cancellable {
 
         setLocationWorldBiomeLight(evt.getPlayer().getLocation().getBlock());
         setWeatherTimeHeight(location);
-        setTool(evt.getPlayer());
+        setTool(evt.getPlayer(), EquipmentSlot.HAND);
         setRegions();
     }
 
     public OccurredEvent(PlayerItemConsumeEvent evt) {
-        super(new PlayerSubject(evt.getPlayer()), Trigger.CONSUME_ITEM);
+        super(new PlayerSubject(evt.getPlayer(), evt.getHand()), Trigger.CONSUME_ITEM);
         event = evt;
         setLocationWorldBiomeLight(evt.getPlayer().getLocation().getBlock());
         setWeatherTimeHeight(location);
-        setTool(evt.getPlayer());
+        setTool(evt.getPlayer(), evt.getHand());
         setRegions();
     }
     
     public OccurredEvent(JobsLevelUpEvent evt) {
-    	super(new PlayerSubject(evt.getPlayer().getPlayer()), Trigger.JOBS_LEVEL_UP);
+    	super(new PlayerSubject(evt.getPlayer().getPlayer(), EquipmentSlot.HAND), Trigger.JOBS_LEVEL_UP);
     	event = evt;
     	setJobName(evt.getJob().getName());
         setJobLevel(evt.getLevel());
@@ -692,7 +698,7 @@ public class OccurredEvent extends AbstractDropEvent implements Cancellable {
     }
     
     public OccurredEvent(JobsPaymentEvent evt) {
-    	super(new PlayerSubject(evt.getPlayer().getPlayer()), Trigger.JOBS_PAYMENT);
+    	super(new PlayerSubject(evt.getPlayer().getPlayer(), EquipmentSlot.HAND), Trigger.JOBS_PAYMENT);
     	event = evt;
         setLocationWorldBiomeLight(evt.getPlayer().getPlayer().getLocation().getBlock());
         setWeatherTimeHeight(location);
@@ -700,7 +706,7 @@ public class OccurredEvent extends AbstractDropEvent implements Cancellable {
     }
     
     public OccurredEvent(JobsExpGainEvent evt) {
-    	super(new PlayerSubject(evt.getPlayer().getPlayer()), Trigger.JOBS_EXP_GAIN);
+    	super(new PlayerSubject(evt.getPlayer().getPlayer(), EquipmentSlot.HAND), Trigger.JOBS_EXP_GAIN);
     	event = evt;
         setJobName(evt.getJob().getName());
         setJobLevel(Jobs.getPlayerManager().getJobsPlayer(evt.getPlayer().getUniqueId()).getJobProgression(evt.getJob()).getLevel());
@@ -724,7 +730,7 @@ public class OccurredEvent extends AbstractDropEvent implements Cancellable {
         event = evt;
         setLocationWorldBiomeLight(evt.getPlayer().getLocation().getBlock());
         setWeatherTimeHeight(location);
-        setTool(evt.getPlayer());
+        setTool(evt.getPlayer(), EquipmentSlot.HAND); // Default to off-hand
         setRegions();
     }
 
@@ -758,7 +764,7 @@ public class OccurredEvent extends AbstractDropEvent implements Cancellable {
         }
         setLocationWorldBiomeLight(block);
         setWeatherTimeHeight(location);
-        setTool(evt.getPlayer());
+        setTool(evt.getPlayer(), evt.getHand());
         attackRange = measureRange(
                 location,
                 evt.getPlayer().getLocation(),
@@ -838,9 +844,9 @@ public class OccurredEvent extends AbstractDropEvent implements Cancellable {
         tool = agent;
     }
 
-    private void setTool(Entity damager) {
+    private void setTool(Entity damager, EquipmentSlot hand) {
         if (damager instanceof Player)
-            tool = new PlayerSubject((Player) damager);
+            tool = new PlayerSubject((Player) damager, hand);
         else if (damager instanceof Projectile)
             tool = new ProjectileAgent((Projectile) damager);
         else if (damager instanceof LightningStrike)
@@ -866,8 +872,8 @@ public class OccurredEvent extends AbstractDropEvent implements Cancellable {
         // Check if the damager is a player - if so, weapon is the held tool
         if (lastDamage instanceof EntityDamageByEntityEvent) {
             EntityDamageByEntityEvent e = (EntityDamageByEntityEvent) lastDamage;
-            if (e.getDamager() instanceof Player) {
-                tool = new PlayerSubject((Player) e.getDamager());
+            if (e.getDamager() instanceof Player p) {
+                tool = new PlayerSubject((Player) e.getDamager(), EquipmentSlotResolver.resolve(e.getCause(), p));
                 return;
             } else if (e.getDamager() instanceof Projectile) {
                 tool = new ProjectileAgent((Projectile) e.getDamager());
@@ -906,7 +912,7 @@ public class OccurredEvent extends AbstractDropEvent implements Cancellable {
 
     private static Target getEntityTarget(Entity what) {
         if (what instanceof Player)
-            return new PlayerSubject((Player) what);
+            return new PlayerSubject((Player) what, EquipmentSlot.HAND); // default to main hand?
         else if (what instanceof LivingEntity) {
             if(Dependencies.hasMythicMobs()) {
                 ActiveMob mythicMob = Dependencies.getMythicMobs().getMobManager().getActiveMob(what.getUniqueId()).orElse(null);
@@ -1132,8 +1138,7 @@ public class OccurredEvent extends AbstractDropEvent implements Cancellable {
             return ((PlayerSubject) getTool()).getPlayer();
         else if (getTool() instanceof ProjectileAgent) {
             if (((ProjectileAgent) getTool()).getShooter() instanceof PlayerSubject)
-                return (Player) ((ProjectileAgent) getTool()).getShooter()
-                        .getEntity();
+                return (Player) ((ProjectileAgent) getTool()).getShooter().getEntity();
         }
 
         return null;

--- a/src/com/gmail/zariust/otherdrops/listener/OdPlayerListener.java
+++ b/src/com/gmail/zariust/otherdrops/listener/OdPlayerListener.java
@@ -32,7 +32,6 @@ import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
-import org.bukkit.inventory.EquipmentSlot;
 
 import java.util.HashSet;
 
@@ -47,9 +46,6 @@ public class OdPlayerListener implements Listener {
     public void onPlayerInteract(PlayerInteractEvent event) {
         // Deliberately processing cancelled events as a click into air
         // is always "cancelled" and we want to catch that event
-        if (event.getHand() == EquipmentSlot.OFF_HAND) {
-            return; // off hand packet, ignore.
-        }
         if (event.isCancelled() && (event.getAction() == Action.LEFT_CLICK_BLOCK || event.getAction() == Action.RIGHT_CLICK_BLOCK)) {
             Log.logInfo("Cancelled event but not AIR - skipping.", Verbosity.HIGHEST);
             return;
@@ -81,9 +77,6 @@ public class OdPlayerListener implements Listener {
 
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
     public void onPlayerInteractEntity(PlayerInteractEntityEvent event) {
-        if (event.getHand() == EquipmentSlot.OFF_HAND) {
-            return; // off hand packet, ignore.
-        }
         if (event.isCancelled())
             return;
         if (event.getPlayer() != null)

--- a/src/com/gmail/zariust/otherdrops/subject/PlayerSubject.java
+++ b/src/com/gmail/zariust/otherdrops/subject/PlayerSubject.java
@@ -21,6 +21,7 @@ import com.gmail.zariust.otherdrops.options.ToolDamage;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.Collections;
@@ -29,6 +30,7 @@ import java.util.Random;
 
 public class PlayerSubject extends LivingSubject {
     private ToolAgent tool;
+    private EquipmentSlot hand;
     private String    name;
     private Player    agent;
     private boolean   anyObject;
@@ -46,8 +48,9 @@ public class PlayerSubject extends LivingSubject {
         this(null, attacker);
     }
 
-    public PlayerSubject(Player attacker) {
-        this(attacker.getInventory().getItemInMainHand(), attacker.getName(), attacker);
+    public PlayerSubject(Player attacker, EquipmentSlot hand) {
+        this(attacker.getInventory().getItem(hand), attacker.getName(), attacker);
+        this.hand = hand;
     }
 
     public PlayerSubject(ItemStack item, String attacker) {
@@ -123,7 +126,7 @@ public class PlayerSubject extends LivingSubject {
     public void damageTool(ToolDamage damage, Random rng) {
         if (damage == null)
             return;
-        ItemStack stack = agent.getInventory().getItemInMainHand();
+        ItemStack stack = agent.getInventory().getItem(hand);
         if (stack == null)
             return;
         if (damage.apply(stack, rng))

--- a/src/com/gmail/zariust/otherdrops/subject/ProjectileAgent.java
+++ b/src/com/gmail/zariust/otherdrops/subject/ProjectileAgent.java
@@ -19,6 +19,7 @@ package com.gmail.zariust.otherdrops.subject;
 import com.gmail.zariust.common.CommonEntity;
 import com.gmail.zariust.common.Verbosity;
 import com.gmail.zariust.otherdrops.Dependencies;
+import com.gmail.zariust.otherdrops.EquipmentSlotResolver;
 import com.gmail.zariust.otherdrops.Log;
 import com.gmail.zariust.otherdrops.data.CreatureData;
 import com.gmail.zariust.otherdrops.data.Data;
@@ -27,7 +28,9 @@ import io.lumine.mythic.core.mobs.ActiveMob;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.*;
+import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
 
 import java.util.Random;
 
@@ -102,8 +105,17 @@ public class ProjectileAgent implements Agent {
     		shooter = (LivingEntity) missile.getShooter();
         if (shooter == null)
             return null;
-        else if (shooter instanceof Player)
-            return new PlayerSubject((Player) shooter);
+        else if (shooter instanceof Player player) {
+            EquipmentSlot hand = EquipmentSlot.HAND;
+            if(missile instanceof ThrowableProjectile thrown) {
+                ItemStack stack = thrown.getItem();
+                if(stack.isSimilar(player.getInventory().getItem(EquipmentSlot.OFF_HAND)))
+                    hand = EquipmentSlot.OFF_HAND;
+            } else {
+                hand = EquipmentSlotResolver.getHandWithMaterial(player.getInventory(), Material.BOW, true);
+            }
+            return new PlayerSubject(player, hand);
+        }
         else {
             if(Dependencies.hasMythicMobs()) {
                 ActiveMob mythicMob = Dependencies.getMythicMobs().getMobManager().getActiveMob(shooter.getUniqueId()).orElse(null);


### PR DESCRIPTION
This implementation instead allows playersubject to specify which hand to declare as the tool. We have un-ignored the offhand packet, process all drops twice, once for main once for off hand. 

Optional TODO: might be to allow specifying which hand we want in `tool:` ?